### PR TITLE
Added "paid" role to get_verified_user() allowed roles list.

### DIFF
--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -323,7 +323,9 @@ def get_current_user_by_api_key(api_key: str):
 
 
 def get_verified_user(user=Depends(get_current_user)):
-    if user.role not in {"user", "admin"}:
+    # Allow access for users with "user", "admin", or "paid" roles
+    # "paid" role has the same permissions as "user" role
+    if user.role not in {"user", "admin", "paid"}:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,


### PR DESCRIPTION
- Added "paid" role to allowed roles in get_verified_user()
- "paid" role now has same permissions as "user" role
- Resolves access permission errors for paid users

Fixes API access for users with "paid" role who were previously
getting "You do not have permission to access this resource" error
when accessing /api/models endpoint.