### PR TITLE
refactor: centralize user role constants

### DIFF
--- a/backend/open_webui/constants.py
+++ b/backend/open_webui/constants.py
@@ -1,6 +1,23 @@
 from enum import Enum
 
 
+class USER_ROLES(str, Enum):
+    def __str__(self) -> str:
+        return super().__str__()
+
+    ADMIN = "admin"
+    USER = "user"
+    PAID = "paid"
+    PENDING = "pending"
+
+
+# Privileged roles that have access to the main application
+PRIVILEGED_ROLES = {USER_ROLES.USER, USER_ROLES.ADMIN, USER_ROLES.PAID}
+
+# Roles that can access admin-only endpoints
+ADMIN_ROLES = {USER_ROLES.ADMIN}
+
+
 class MESSAGES(str, Enum):
     DEFAULT = lambda msg="": f"{msg if msg else ''}"
     MODEL_ADDED = lambda model="": f"The model '{model}' has been added successfully."

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -18,7 +18,7 @@ from opentelemetry import trace
 from open_webui.utils.jwt_keycloak_validate import decodeAndValidateToken
 from open_webui.models.users import Users
 
-from open_webui.constants import ERROR_MESSAGES
+from open_webui.constants import ERROR_MESSAGES, PRIVILEGED_ROLES, ADMIN_ROLES
 from open_webui.env import (
     KEYCLOAK_ISSUER,
     WEBUI_SECRET_KEY,
@@ -323,9 +323,9 @@ def get_current_user_by_api_key(api_key: str):
 
 
 def get_verified_user(user=Depends(get_current_user)):
-    # Allow access for users with "user", "admin", or "paid" roles
-    # "paid" role has the same permissions as "user" role
-    if user.role not in {"user", "admin", "paid"}:
+    # Allow access for users with privileged roles (user, admin, paid)
+    # All privileged roles have the same basic access permissions
+    if user.role not in PRIVILEGED_ROLES:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -334,7 +334,7 @@ def get_verified_user(user=Depends(get_current_user)):
 
 
 def get_admin_user(user=Depends(get_current_user)):
-    if user.role != "admin":
+    if user.role not in ADMIN_ROLES:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -97,6 +97,20 @@ export const SUPPORTED_FILE_EXTENSIONS = [
 
 export const PASTED_TEXT_CHARACTER_LIMIT = 1000;
 
+// User Roles Constants
+export const USER_ROLES = {
+	ADMIN: 'admin',
+	USER: 'user',
+	PAID: 'paid',
+	PENDING: 'pending'
+} as const;
+
+// Privileged roles that have access to the main application
+export const PRIVILEGED_ROLES = [USER_ROLES.USER, USER_ROLES.ADMIN, USER_ROLES.PAID];
+
+// Roles that can access admin-only endpoints
+export const ADMIN_ROLES = [USER_ROLES.ADMIN];
+
 // Source: https://kit.svelte.dev/docs/modules#$env-static-public
 // This feature, akin to $env/static/private, exclusively incorporates environment variables
 // that are prefixed with config.kit.env.publicPrefix (usually set to PUBLIC_).

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -19,7 +19,7 @@
 	import { getBanners } from '$lib/apis/configs';
 	import { getUserSettings } from '$lib/apis/users';
 
-	import { WEBUI_BASE_URL, WEBUI_VERSION } from '$lib/constants';
+	import { WEBUI_BASE_URL, WEBUI_VERSION, PRIVILEGED_ROLES } from '$lib/constants';
 	import { compareVersion } from '$lib/utils';
 
 	import {
@@ -61,7 +61,8 @@
 		if ($user === undefined || $user === null) {
 			console.log({user: $user})
 			// keycloak.logout()
-		} else if (['user', 'admin'].includes($user?.role)) {
+		} else if (PRIVILEGED_ROLES.includes($user?.role)) {
+			// Initialize app data for users with privileged roles
 			try {
 				// Check if IndexedDB exists
 				DB = await openDB('Chats', 1);
@@ -279,7 +280,9 @@
 		<div
 			class=" text-gray-700 dark:text-gray-100 bg-white dark:bg-gray-900 h-screen max-h-[100dvh] overflow-auto flex flex-row justify-end"
 		>
-			{#if !['user', 'admin'].includes($user?.role)}
+			{#if !PRIVILEGED_ROLES.includes($user?.role)}
+				<!-- Show account pending overlay for users without privileged roles -->
+				<!-- Privileged roles: user, admin, paid -->
 				<AccountPending />
 			{:else}
 				{#if localDBChats.length > 0}


### PR DESCRIPTION
refactor: centralize user role constants

- Add USER_ROLES enum and PRIVILEGED_ROLES/ADMIN_ROLES constants to backend
- Add corresponding role constants to frontend  
- Update auth.py to use centralized role constants
- Update layout.svelte to use PRIVILEGED_ROLES constant
- Improve maintainability: new roles can be added by updating constants only

This refactor makes role management more maintainable and reduces the risk
of missing role checks when adding new user roles. The "paid" role is now
properly integrated through the centralized constants system.